### PR TITLE
Update readme: Xamarin.Mac is not supported

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -88,12 +88,12 @@ If anyone verifies any of the above, please submit a [Pull Request](https://help
  * Xamarin.Android
  * Xamarin.Mac
    * Xamarin.Mac fails when calling GetText with:
- ```
- System.DllNotFoundException: User32.dll
-  at at (wrapper managed-to-native) WindowsClipboard.IsClipboardFormatAvailable(uint)
-  at WindowsClipboard.GetText () [0x00000] in <b38d6b05b12944c3a3542953bdff5fbe>:0
-  at TextCopy.Clipboard.GetText () [0x00000] in <b38d6b05b12944c3a3542953bdff5fbe>:0
-```
+     ```
+     System.DllNotFoundException: User32.dll
+       at at (wrapper managed-to-native) WindowsClipboard.IsClipboardFormatAvailable(uint)
+       at WindowsClipboard.GetText () [0x00000] in <b38d6b05b12944c3a3542953bdff5fbe>:0
+       at TextCopy.Clipboard.GetText () [0x00000] in <b38d6b05b12944c3a3542953bdff5fbe>:0
+     ```
 
 If support is required, please submit a [Pull Request](https://help.github.com/articles/about-pull-requests/) that adds support.
 

--- a/readme.md
+++ b/readme.md
@@ -79,7 +79,6 @@ var text = TextCopy.Clipboard.GetText();
 The following may work but have not been verified:
 
  * Xamarin.iOS
- * Xamarin.Mac
 
 If anyone verifies any of the above, please submit a [Pull Request](https://help.github.com/articles/about-pull-requests/) to the readme with the outcome.
 
@@ -87,6 +86,14 @@ If anyone verifies any of the above, please submit a [Pull Request](https://help
 ### Not supported
 
  * Xamarin.Android
+ * Xamarin.Mac
+ ** Xamarin.Mac fails when calling GetText with:
+ <!-- snippet -->
+ System.DllNotFoundException: User32.dll
+  at at (wrapper managed-to-native) WindowsClipboard.IsClipboardFormatAvailable(uint)
+  at WindowsClipboard.GetText () [0x00000] in <b38d6b05b12944c3a3542953bdff5fbe>:0
+  at TextCopy.Clipboard.GetText () [0x00000] in <b38d6b05b12944c3a3542953bdff5fbe>:0
+<!-- endsnippet -->
 
 If support is required, please submit a [Pull Request](https://help.github.com/articles/about-pull-requests/) that adds support.
 

--- a/readme.md
+++ b/readme.md
@@ -87,13 +87,13 @@ If anyone verifies any of the above, please submit a [Pull Request](https://help
 
  * Xamarin.Android
  * Xamarin.Mac
- ** Xamarin.Mac fails when calling GetText with:
- <!-- snippet -->
+   * Xamarin.Mac fails when calling GetText with:
+ ```
  System.DllNotFoundException: User32.dll
   at at (wrapper managed-to-native) WindowsClipboard.IsClipboardFormatAvailable(uint)
   at WindowsClipboard.GetText () [0x00000] in <b38d6b05b12944c3a3542953bdff5fbe>:0
   at TextCopy.Clipboard.GetText () [0x00000] in <b38d6b05b12944c3a3542953bdff5fbe>:0
-<!-- endsnippet -->
+```
 
 If support is required, please submit a [Pull Request](https://help.github.com/articles/about-pull-requests/) that adds support.
 


### PR DESCRIPTION
I'm using TextCopy.Clipboard.GetText() from a Xamarin.Mac (Modern) app and it throws an exception. I will probably look into this within the next month but if you have any pointers on where I might start that would be appreciated.