### PR TITLE
Xamarin.Mac Modern is supported

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,6 +69,7 @@ var text = TextCopy.Clipboard.GetText();
  * Windows with Mono 5.0 and up
  * OSX with .NET Core 2.0 and up
  * OSX with Mono 5.20.1 and up
+ * Xamarin.Mac Modern, .NET Core 2.0
  * Linux with .NET Core 2.0 and up
  * Linux with Mono 5.20.1 and up
  * Universal Windows Platform version 10.0.16299 and up
@@ -79,22 +80,21 @@ var text = TextCopy.Clipboard.GetText();
 The following may work but have not been verified:
 
  * Xamarin.iOS
- * Xamarin.Mac
 
-If anyone verifies any of the above, please submit a [Pull Request](https://help.github.com/articles/about-pull-requests/) to the readme with the outcome.
+If anyone verifies this, please submit a [Pull Request](https://help.github.com/articles/about-pull-requests/) to the readme with the outcome.
 
 
 ### Not supported
 
  * Xamarin.Android
- * Xamarin.Mac. Fails when calling GetText with:
-    ```
+ * Xamarin.Mac Full, .NET Framework 4.7.2
+     ```
     System.DllNotFoundException: User32.dll
       at at (wrapper managed-to-native)WindowsClipboard.IsClipboardFormatAvailable(uint)
       at WindowsClipboard.GetText()
       at TextCopy.Clipboard.GetText()
     ```
-
+ 
 If support is required, please submit a [Pull Request](https://help.github.com/articles/about-pull-requests/) that adds support.
 
 

--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ var text = TextCopy.Clipboard.GetText();
  * Windows with Mono 5.0 and up
  * OSX with .NET Core 2.0 and up
  * OSX with Mono 5.20.1 and up
- * Xamarin.Mac Modern, .NET Core 2.0
+ * Xamarin.Mac Modern
  * Linux with .NET Core 2.0 and up
  * Linux with Mono 5.20.1 and up
  * Universal Windows Platform version 10.0.16299 and up

--- a/readme.source.md
+++ b/readme.source.md
@@ -37,6 +37,7 @@ snippet: GetText
  * Windows with Mono 5.0 and up
  * OSX with .NET Core 2.0 and up
  * OSX with Mono 5.20.1 and up
+ * Xamarin.Mac Modern, .NET Core 2.0
  * Linux with .NET Core 2.0 and up
  * Linux with Mono 5.20.1 and up
  * Universal Windows Platform version 10.0.16299 and up
@@ -47,22 +48,21 @@ snippet: GetText
 The following may work but have not been verified:
 
  * Xamarin.iOS
- * Xamarin.Mac
 
-If anyone verifies any of the above, please submit a [Pull Request](https://help.github.com/articles/about-pull-requests/) to the readme with the outcome.
+If anyone verifies this, please submit a [Pull Request](https://help.github.com/articles/about-pull-requests/) to the readme with the outcome.
 
 
 ### Not supported
 
  * Xamarin.Android
- * Xamarin.Mac. Fails when calling GetText with:
-    ```
+ * Xamarin.Mac Full, .NET Framework 4.7.2
+     ```
     System.DllNotFoundException: User32.dll
       at at (wrapper managed-to-native)WindowsClipboard.IsClipboardFormatAvailable(uint)
       at WindowsClipboard.GetText()
       at TextCopy.Clipboard.GetText()
     ```
-
+ 
 If support is required, please submit a [Pull Request](https://help.github.com/articles/about-pull-requests/) that adds support.
 
 

--- a/readme.source.md
+++ b/readme.source.md
@@ -37,7 +37,7 @@ snippet: GetText
  * Windows with Mono 5.0 and up
  * OSX with .NET Core 2.0 and up
  * OSX with Mono 5.20.1 and up
- * Xamarin.Mac Modern, .NET Core 2.0
+ * Xamarin.Mac Modern
  * Linux with .NET Core 2.0 and up
  * Linux with Mono 5.20.1 and up
  * Universal Windows Platform version 10.0.16299 and up


### PR DESCRIPTION
Update Readme to clarify Xamarin.Mac Modern **is** supported but Xamarin.Mac Full (.NET Framework 4.7.2) is not.

Last night I re-targeted my Xamarin.Mac app to the "Modern" framework. This morning I thought I'd try fixing this and found it was working. Verified both GetText and SetText are working.