### PR TITLE
Add Async suffix to public API

### DIFF
--- a/readme.source.md
+++ b/readme.source.md
@@ -12,12 +12,12 @@ toc
 ## Usage
 
 
-### SetText
+### SetTextAsync
 
 snippet: SetTextAsync
 
 
-### GetText
+### GetTextAsync
 
 snippet: GetTextAsync
 

--- a/readme.source.md
+++ b/readme.source.md
@@ -14,12 +14,12 @@ toc
 
 ### SetText
 
-snippet: SetText
+snippet: SetTextAsync
 
 
 ### GetText
 
-snippet: GetText
+snippet: GetTextAsync
 
 
 ## Compatibility

--- a/src/TestConsole/Program.cs
+++ b/src/TestConsole/Program.cs
@@ -6,8 +6,8 @@ class Program
     static async Task<int> Main()
     {
         var text = "Hello World!";
-        await Clipboard.SetText(text);
-        var result = await Clipboard.GetText();
+        await Clipboard.SetTextAsync(text);
+        var result = await Clipboard.GetTextAsync();
         if (result == text)
         {
             return 0;

--- a/src/Tests/ClipboardTests.cs
+++ b/src/Tests/ClipboardTests.cs
@@ -16,9 +16,9 @@ public class ClipboardTests :
 
     static async Task VerifyInner(string expected)
     {
-        await Clipboard.SetText(expected);
+        await Clipboard.SetTextAsync(expected);
 
-        var actual = await Clipboard.GetText();
+        var actual = await Clipboard.GetTextAsync();
         Assert.Equal(expected, actual);
     }
 

--- a/src/Tests/Snippets.cs
+++ b/src/Tests/Snippets.cs
@@ -2,20 +2,20 @@
 
 class Snippets
 {
-    async Task SetText()
+    async Task SetTextAsync()
     {
-        #region SetText
+        #region SetTextAsync
 
-        await TextCopy.Clipboard.SetText("Text to place in clipboard");
+        await TextCopy.Clipboard.SetTextAsync("Text to place in clipboard");
 
         #endregion
     }
 
-    async Task GetText()
+    async Task GetTextAsync()
     {
-        #region GetText
+        #region GetTextAsync
 
-        var text = await TextCopy.Clipboard.GetText();
+        var text = await TextCopy.Clipboard.GetTextAsync();
 
         #endregion
     }

--- a/src/TextCopy/Clipboard.cs
+++ b/src/TextCopy/Clipboard.cs
@@ -14,7 +14,7 @@ namespace TextCopy
         /// <summary>
         /// Retrieves text data from the Clipboard.
         /// </summary>
-        public static Task<string?> GetText(CancellationToken cancellation = default)
+        public static Task<string?> GetTextAsync(CancellationToken cancellation = default)
         {
             return getFunc(cancellation);
         }
@@ -24,7 +24,7 @@ namespace TextCopy
         /// <summary>
         /// Clears the Clipboard and then adds text data to it.
         /// </summary>
-        public static Task SetText(string text, CancellationToken cancellation = default)
+        public static Task SetTextAsync(string text, CancellationToken cancellation = default)
         {
             Guard.AgainstNull(text, nameof(text));
             return setAction(text,cancellation);

--- a/src/UapApp/MainPage.xaml.cs
+++ b/src/UapApp/MainPage.xaml.cs
@@ -14,8 +14,8 @@ namespace UapApp
 
         async void OutputClipboardText()
         {
-            await TextCopy.Clipboard.SetText("AAA");
-            var text = await TextCopy.Clipboard.GetText();
+            await TextCopy.Clipboard.SetTextAsync("AAA");
+            var text = await TextCopy.Clipboard.GetTextAsync();
             Debug.WriteLine(text);
         }
     }


### PR DESCRIPTION
The convention of `Task` returning methods is to add an `Async` suffix to the method names. This also eases users who were on 1.x to upgrade to 2.x gracefully without unknowingly introducing breaking changes.

I had code previously written like this:

```c#
public interface IClipboard
{
    void SetText(string s);
}

public class TextCopyClipboard : IClipboard
{
    public void SetText(string s) => TextCopy.Clipboard.SetText(s);
}
```
This works fine because `SetText` and `GetText` were synchronous before 2.x. When I upgraded to 2.x there are no compile errors but this is actually broken code because `SetText` and `GetText` are now asynchronous.

I suggest making it obvious and rename the methods with an `Async` suffix.