### PR TITLE
Add wayland support with wl-clipboard

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -175,7 +175,7 @@ Blazor support requires the browser APIs [clipboard.readText](https://caniuse.co
 
 TextCopy supports X11 and Wayland with additional dependencies.
 
-The following utilities are used to access the clipboard with the respective window system, they must be installed and callable.
+The following utilities are used to access the clipboard with the respective window system. Make sure to install the utility for the window system you are using:
 - **X11** [xsel](https://github.com/kfish/xsel)
 - **Wayland** [wl-clipboard](https://github.com/bugaevc/wl-clipboard)
 

--- a/readme.md
+++ b/readme.md
@@ -173,7 +173,11 @@ Blazor support requires the browser APIs [clipboard.readText](https://caniuse.co
 
 ## Linux
 
-Linux uses [xsel](https://github.com/kfish/xsel) to access the clipboard. As such it needs to be installed and callable.
+TextCopy supports X11 and Wayland with additional dependencies.
+
+The following utilities are used to access the clipboard with the respective window system, they must be installed and callable.
+- **X11** [xsel](https://github.com/kfish/xsel)
+- **Wayland** [wl-clipboard](https://github.com/bugaevc/wl-clipboard)
 
 
 ## Icon

--- a/src/TextCopy/LinuxClipboard_2.0.cs
+++ b/src/TextCopy/LinuxClipboard_2.0.cs
@@ -53,7 +53,7 @@ static class LinuxClipboard
                         break;
                     case WindowSystem.Wayland:
                         // wl-copy keeps stderr open. Since there is no straightforward way for us to wait for errors, just ignore them.
-                        BashRunner.Run($"cat {tempFileName} | /home/arthur/Documents/wl-clipboard/build/wl-copy -n ");
+                        BashRunner.Run($"cat {tempFileName} | wl-copy -n 2>/dev/null ");
                         break;
                 }
             }

--- a/src/TextCopy/LinuxClipboard_2.0.cs
+++ b/src/TextCopy/LinuxClipboard_2.0.cs
@@ -19,12 +19,9 @@ static class LinuxClipboard
     {
         isWsl = Environment.GetEnvironmentVariable("WSL_DISTRO_NAME") != null;
 
-        windowSystem = Environment.GetEnvironmentVariable("XDG_SESSION_TYPE") switch
-        {
-            "x11" => WindowSystem.X11,
-            "wayland" => WindowSystem.Wayland,
-            _ => throw new NotSupportedException()
-        };
+        // XDG_SESSION_TYPE is a systemd(1) environment variable and is unlikely set in non-systemd environments.
+        // Therefore we check the Wayland specific display environment variable first and fall back to x11.
+        windowSystem = Environment.GetEnvironmentVariable("WAYLAND_DISPLAY") != null ? WindowSystem.Wayland : WindowSystem.X11;
     }
 
     public static Task SetTextAsync(string text, CancellationToken cancellation)

--- a/src/TextCopy/LinuxClipboard_2.1.cs
+++ b/src/TextCopy/LinuxClipboard_2.1.cs
@@ -6,11 +6,25 @@ using System.Threading.Tasks;
 
 static class LinuxClipboard
 {
+    enum WindowSystem
+    {
+        X11,
+        Wayland
+    }
+
     static bool isWsl;
+    static WindowSystem windowSystem;
 
     static LinuxClipboard()
     {
         isWsl = Environment.GetEnvironmentVariable("WSL_DISTRO_NAME") != null;
+
+        windowSystem = Environment.GetEnvironmentVariable("XDG_SESSION_TYPE") switch
+        {
+            "x11" => WindowSystem.X11,
+            "wayland" => WindowSystem.Wayland,
+            _ => throw new NotSupportedException()
+        };
     }
 
     public static async Task SetTextAsync(string text, CancellationToken cancellation)
@@ -43,7 +57,16 @@ static class LinuxClipboard
             }
             else
             {
-                BashRunner.Run($"cat {tempFileName} | xsel -i --clipboard ");
+                switch (windowSystem)
+                {
+                    case WindowSystem.X11:
+                        BashRunner.Run($"cat {tempFileName} | xsel -i --clipboard ");
+                        break;
+                    case WindowSystem.Wayland:
+                        // wl-copy keeps stderr open. Since there is no straightforward way for us to wait for errors, just ignore them.
+                        BashRunner.Run($"cat {tempFileName} | /home/arthur/Documents/wl-clipboard/build/wl-copy -n 2>/dev/null ");
+                        break;
+                }
             }
         }
         finally
@@ -84,11 +107,19 @@ static class LinuxClipboard
     {
         if (isWsl)
         {
-            BashRunner.Run($"powershell.exe Get-Clipboard  > {tempFileName}");
+            BashRunner.Run($"powershell.exe Get-Clipboard > {tempFileName}");
         }
         else
         {
-            BashRunner.Run($"xsel -o --clipboard  > {tempFileName}");
+            switch (windowSystem)
+            {
+                case WindowSystem.X11:
+                    BashRunner.Run($"xsel -o --clipboard > {tempFileName}");
+                    break;
+                case WindowSystem.Wayland:
+                    BashRunner.Run($"wl-paste -n > {tempFileName}");
+                    break;
+            }
         }
     }
 }

--- a/src/TextCopy/LinuxClipboard_2.1.cs
+++ b/src/TextCopy/LinuxClipboard_2.1.cs
@@ -19,12 +19,9 @@ static class LinuxClipboard
     {
         isWsl = Environment.GetEnvironmentVariable("WSL_DISTRO_NAME") != null;
 
-        windowSystem = Environment.GetEnvironmentVariable("XDG_SESSION_TYPE") switch
-        {
-            "x11" => WindowSystem.X11,
-            "wayland" => WindowSystem.Wayland,
-            _ => throw new NotSupportedException()
-        };
+        // XDG_SESSION_TYPE is a systemd(1) environment variable and is unlikely set in non-systemd environments.
+        // Therefore we check the Wayland specific display environment variable first and fall back to x11.
+        windowSystem = Environment.GetEnvironmentVariable("WAYLAND_DISPLAY") != null ? WindowSystem.Wayland : WindowSystem.X11;
     }
 
     public static async Task SetTextAsync(string text, CancellationToken cancellation)

--- a/src/TextCopy/LinuxClipboard_2.1.cs
+++ b/src/TextCopy/LinuxClipboard_2.1.cs
@@ -64,7 +64,7 @@ static class LinuxClipboard
                         break;
                     case WindowSystem.Wayland:
                         // wl-copy keeps stderr open. Since there is no straightforward way for us to wait for errors, just ignore them.
-                        BashRunner.Run($"cat {tempFileName} | /home/arthur/Documents/wl-clipboard/build/wl-copy -n 2>/dev/null ");
+                        BashRunner.Run($"cat {tempFileName} | wl-copy -n 2>/dev/null ");
                         break;
                 }
             }


### PR DESCRIPTION
Hi, I've added wayland support with wl-clipboard! :)

I'm using `XDG_SESSION_TYPE` to detect the correct session, but apparently this isn't a foolproof way if users are running non-standard systems (systems without display manager, but do those people even have a clipboard?). I don't think we can account for everything, so in my opinion this is fine.

I've opted for throwing an error if the session type isn't `x11` or `wayland`. For example it could be `tty` for which there isn't a clipboard(?). It could be changed to x11 as default.